### PR TITLE
Respect bottom padding on iPhone X

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,9 @@ tarballs/
 test-results/
 Thumbs.db
 
+# Visual Studio
+.vs/
+
 # Mac bundle stuff
 *.dmg
 *.app

--- a/ProXamTabsSample/ProXamTabsSample/TabsPage.xaml
+++ b/ProXamTabsSample/ProXamTabsSample/TabsPage.xaml
@@ -2,7 +2,9 @@
 <ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="ProXamTabsSample.TabsPage"
-             xmlns:pxTabs="clr-namespace:Plugin.ProXamTabs.Shared;assembly=Plugin.ProXamTabs">
+             xmlns:pxTabs="clr-namespace:Plugin.ProXamTabs.Shared;assembly=Plugin.ProXamTabs"
+             xmlns:ios="clr-namespace:Xamarin.Forms.PlatformConfiguration.iOSSpecific;assembly=Xamarin.Forms.Core" 
+             ios:Page.UseSafeArea="true">
     <ContentPage.Content>
         <pxTabs:PXTabsView
             x:Name="tabsView"


### PR DESCRIPTION
This PR updates the sample project to ensure the bottom padding on the iPhone X is respected. Without these changes the tab bar will be drawn on top of the microphone which doesn't look nice.

More information can be found here: https://blog.xamarin.com/making-ios-11-even-easier-xamarin-forms/