### PR TITLE
Fix `NullReferenceException` when using `SelectedTabIndex` in XAML

### DIFF
--- a/ProXamTabs/Shared/BasePXTabsLayout.cs
+++ b/ProXamTabs/Shared/BasePXTabsLayout.cs
@@ -100,7 +100,7 @@ namespace Plugin.ProXamTabs.Shared
 
         private void TabSelected(int index)
         {            
-            if (Tabs.Count() > index)
+            if (Tabs?.Count() > index)
             {
                 TabSelected(Tabs.ElementAt(index));
             }

--- a/ProXamTabsSample/ProXamTabsSample.Android/ProXamTabsSample.Android.csproj
+++ b/ProXamTabsSample/ProXamTabsSample.Android/ProXamTabsSample.Android.csproj
@@ -15,7 +15,7 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
-    <AndroidUseLatestPlatformSdk>true</AndroidUseLatestPlatformSdk>
+    <AndroidUseLatestPlatformSdk>false</AndroidUseLatestPlatformSdk>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
   </PropertyGroup>

--- a/ProXamTabsSample/ProXamTabsSample.Android/Properties/AndroidManifest.xml
+++ b/ProXamTabsSample/ProXamTabsSample.Android/Properties/AndroidManifest.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="com.companyname.ProXamTabsSample">
-	<uses-sdk android:minSdkVersion="15" />
+﻿<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="com.companyname.ProXamTabsSample" android:installLocation="auto">
+	<uses-sdk android:minSdkVersion="15" android:targetSdkVersion="26" />
 	<application android:label="ProXamTabsSample.Android"></application>
 </manifest>

--- a/ProXamTabsSample/ProXamTabsSample/TabsPage.xaml
+++ b/ProXamTabsSample/ProXamTabsSample/TabsPage.xaml
@@ -14,6 +14,7 @@
             IsBorderVisible="True"
             IsSliderOnBottom="False"
             IsSliderVisible="True"
-            IsTabBarOnTop="False"/>
+            IsTabBarOnTop="False"
+            SelectedTabIndex="1"/>
     </ContentPage.Content>
 </ContentPage>

--- a/ProXamTabsSample/ProXamTabsSample/TabsPage.xaml.cs
+++ b/ProXamTabsSample/ProXamTabsSample/TabsPage.xaml.cs
@@ -36,7 +36,6 @@ namespace ProXamTabsSample
             };
             
             tabsView.Tabs = _tabs;
-            tabsView.SelectedTabIndex = 2;
         }
 
         private PXTab CreateTab(int id, View view, string text, string selectedImage, string unselectedImage, Color selectedColor, Color unselectedColor, int badgeCount = 0)


### PR DESCRIPTION
This PR fixes an issue where a `NullReferenceException` would be thrown when setting the `SelectedTabIndex` property from the XAML like this:

```
<pxTabs:PXTabsView
            x:Name="tabsView"
            SelectedTabIndex="1"/>
```

The sample project contains proof of the bug fix.